### PR TITLE
url option belongs to broker section

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ ids = [0, 1]
 type = "amqp" # only supported type; any other value sends/receives from STDIN/STDOUT
 group = "gateway"
 message_timeout = "2m" # this is the default value: https://golang.org/pkg/time/#ParseDuration
+url = "amqp://localhost"
 
 [prometheus]
 address = ":8080"
@@ -74,9 +75,6 @@ endpoint = "/metrics"
 [shard_store]
 type = "redis" # only supported type
 prefix = "gateway" # string to prefix shard-store keys
-
-[amqp]
-url = "amqp://localhost"
 
 [redis]
 url = "localhost:6379"


### PR DESCRIPTION
In my experience, the url option of the amqp section had no effect. I moved it to the broker section and it works as expected.