### PR TITLE
Rewrite dockerfile to use alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,20 @@
-FROM golang AS build
+FROM golang:alpine AS build
 
 WORKDIR /usr/gateway
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN go build -o build/gateway
+# https://github.com/valyala/gozstd/issues/20
+RUN apk add gcc musl-dev libc-dev make && \
+    GOZSTD_VER=$(cat go.mod | fgrep github.com/valyala/gozstd | awk '{print $NF}') && \
+    go get -d github.com/valyala/gozstd@${GOZSTD_VER} && \
+    cd ${GOPATH}/pkg/mod/github.com/valyala/gozstd@${GOZSTD_VER} && \
+    chmod -R +w . && \
+    make -j8 clean && \
+    make -j8 libzstd.a && \
+    cd /usr/gateway && \
+    go build -o build/gateway
 
-FROM debian:buster-slim AS runtime
-RUN apt-get update -y && apt-get install -y ca-certificates
+FROM alpine:latest
 COPY --from=build /usr/gateway/build/gateway /gateway
 ENTRYPOINT ["/gateway"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN apk add gcc musl-dev libc-dev make && \
     go get -d github.com/valyala/gozstd@${GOZSTD_VER} && \
     cd ${GOPATH}/pkg/mod/github.com/valyala/gozstd@${GOZSTD_VER} && \
     chmod -R +w . && \
-    make -j8 clean && \
-    make -j8 libzstd.a && \
+    make -j $(nproc) clean && \
+    make -j $(nproc) libzstd.a && \
     cd /usr/gateway && \
     go build -o build/gateway
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,7 @@ RUN apk add gcc musl-dev libc-dev make && \
     GOZSTD_VER=$(cat go.mod | fgrep github.com/valyala/gozstd | awk '{print $NF}') && \
     go get -d github.com/valyala/gozstd@${GOZSTD_VER} && \
     cd ${GOPATH}/pkg/mod/github.com/valyala/gozstd@${GOZSTD_VER} && \
-    chmod -R +w . && \
-    make -j $(nproc) clean && \
+    make clean && \
     make -j $(nproc) libzstd.a && \
     cd /usr/gateway && \
     go build -o build/gateway


### PR DESCRIPTION
This reduces the image size from 113mb to 21.2mb. Everything does work fine, zstd was tricky to get working, but luckily [someone already had the same issue](https://github.com/valyala/gozstd/issues/20).