### PR TITLE
feat: trim whitespace from env vars

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -155,12 +155,24 @@ func (c *Config) LoadEnv() {
 
 	v = os.Getenv("DISCORD_EVENTS")
 	if v != "" {
-		c.Events = strings.Split(v, ",")
+		events := strings.Split(v, ",")
+
+		for i, event := range events {
+			events[i] = strings.TrimSpace(event)
+		}
+
+		c.Events = events
 	}
 
 	v = os.Getenv("DISCORD_INTENTS")
 	if v != "" {
-		c.Intents = strings.Split(v, ",")
+		intents := strings.Split(v, ",")
+
+		for i, intent := range intents {
+			intents[i] = strings.TrimSpace(intent)
+		}
+
+		c.Intents = intents
 	}
 
 	v = os.Getenv("DISCORD_RAW_INTENTS")


### PR DESCRIPTION
Allows for more flexibility in assigning `DISCORD_EVENTS` and `DISCORD_INTENTS`:

```env
DISCORD_EVENTS="GUILD_CREATE, GUILD_DELETE,      GUILD_UPDATE"
```

or in `docker-compose.yaml`:

```yaml
services:
  gateway:
    image: spectacles/gateway:latest
    environment:
      DISCORD_EVENTS: >-
        GUILD_CREATE,
        GUILD_DELETE,
        GUILD_UPDATE,
        INTERACTION_CREATE
      DISCORD_INTENTS: >-
        GUILDS,
        GUILD_MESSAGES
  [...]
```
